### PR TITLE
[wip] Changeset index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,9 @@ set(ALL_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${EXPAT_LIBRARIES} ${ROCKSDB_LIBRARI
 #----------------------------------------------------------------------
 add_executable(build_tag_lookup build_tag_lookup.cpp)
 add_executable(add_tags add_tags.cpp)
+add_executable(build_changeset_lookup build_changeset_lookup.cpp)
 
+target_link_libraries(build_changeset_lookup ${ALL_LIBRARIES})
 target_link_libraries(build_tag_lookup ${ALL_LIBRARIES})
 target_link_libraries(add_tags ${ALL_LIBRARIES})
 #-----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ make
 
 ## Run
 
+First build up a changeset index (`http://planet.osm.org/planet/changesets-latest.osm.bz2`).
+
+```
+build_changeset_lookup INDEX_DIR OSM_CHANGESET_FILE
+```
+
 First build up a historic tag index.
 
 ```

--- a/add_tags.cpp
+++ b/add_tags.cpp
@@ -46,7 +46,7 @@ typedef std::map<std::string,std::string> StringStringMap;
 typedef std::map<std::string,std::string> VersionTags;
 typedef std::vector < std::map<std::string, std::string> > TagHistoryArray;
 
-void write_with_history_tags(TagStore* store, const std::string line) {
+void write_with_history_tags(osmwayback::TagStore* store, const std::string line) {
     rapidjson::Document geojson_doc;
     if(geojson_doc.Parse<0>(line.c_str()).HasParseError()) {
         std::cerr << "ERROR" << std::endl;
@@ -213,7 +213,7 @@ int main(int argc, char* argv[]) {
 
     std::string index_dir = argv[1];
     std::cout << "init tag dir" << std::endl;
-    TagStore store(index_dir, false);
+    osmwayback::TagStore store(index_dir, false);
 
     rapidjson::Document doc;
     for (std::string line; std::getline(std::cin, line);) {

--- a/build_changeset_lookup.cpp
+++ b/build_changeset_lookup.cpp
@@ -12,10 +12,10 @@
 #include "db.hpp"
 
 class ChangesetHandler : public osmium::handler::Handler {
-    TagStore* m_store;
+    osmwayback::TagStore* m_store;
 
 public:
-    ChangesetHandler(TagStore* store) : m_store(store) {}
+    ChangesetHandler(osmwayback::TagStore* store) : m_store(store) {}
     void changeset(const osmium::Changeset& changeset) {
         m_store->store_changeset(changeset);
     }
@@ -23,7 +23,7 @@ public:
 
 std::atomic_bool stop_progress{false};
 
-void report_progress(const TagStore* store) {
+void report_progress(const osmwayback::TagStore* store) {
     unsigned long last_changesets_count{0};
     auto start = std::chrono::steady_clock::now();
 
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     std::string index_dir = argv[1];
     std::string changeset_filename = argv[2];
 
-    TagStore store(index_dir, true);
+    osmwayback::TagStore store(index_dir, true);
     ChangesetHandler handler(&store);
 
     std::thread t_progress(report_progress, &store);

--- a/build_changeset_lookup.cpp
+++ b/build_changeset_lookup.cpp
@@ -1,0 +1,67 @@
+#include <cstdlib>  // for std::exit
+#include <cstring>  // for std::strncmp
+#include <iostream> // for std::cout, std::cerr
+#include <sstream>
+#include <chrono>
+
+#include <osmium/io/any_input.hpp>
+#include <osmium/osm/types.hpp>
+#include <osmium/handler.hpp>
+#include <osmium/visitor.hpp>
+
+#include "db.hpp"
+
+class ChangesetHandler : public osmium::handler::Handler {
+    TagStore* m_store;
+
+public:
+    ChangesetHandler(TagStore* store) : m_store(store) {}
+    void changeset(const osmium::Changeset& changeset) {
+        m_store->store_changeset(changeset);
+    }
+};
+
+std::atomic_bool stop_progress{false};
+
+void report_progress(const TagStore* store) {
+    unsigned long last_changesets_count{0};
+    auto start = std::chrono::steady_clock::now();
+
+    while(true) {
+        if(stop_progress) {
+            auto end = std::chrono::steady_clock::now();
+            auto diff = end - start;
+
+            std::cerr << "Processed " << last_changesets_count << " changesets in " << std::chrono::duration <double, std::milli> (diff).count() << " ms" << std::endl;
+            break;
+        }
+
+        auto diff_changesets_count = store->stored_changesets_count - last_changesets_count;
+        std::cerr << "Processing " << diff_changesets_count << " changesets/s" << std::endl;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        last_changesets_count += diff_changesets_count;
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " INDEX_DIR CHANGESET_FILE" << std::endl;
+        std::exit(1);
+    }
+
+    std::string index_dir = argv[1];
+    std::string changeset_filename = argv[2];
+
+    TagStore store(index_dir, true);
+    ChangesetHandler handler(&store);
+
+    std::thread t_progress(report_progress, &store);
+
+    osmium::io::Reader reader{changeset_filename, osmium::osm_entity_bits::changeset};
+    osmium::apply(reader, handler);
+
+    stop_progress = true;
+    t_progress.join();
+    store.flush();
+}

--- a/build_tag_lookup.cpp
+++ b/build_tag_lookup.cpp
@@ -12,10 +12,10 @@
 #include "db.hpp"
 
 class TagStoreHandler : public osmium::handler::Handler {
-    TagStore* m_store;
+    osmwayback::TagStore* m_store;
 
 public:
-    TagStoreHandler(TagStore* store) : m_store(store) {}
+    TagStoreHandler(osmwayback::TagStore* store) : m_store(store) {}
     long node_count = 0;
     int way_count = 0;
     int rel_count = 0;
@@ -37,7 +37,7 @@ public:
 
 std::atomic_bool stop_progress{false};
 
-void report_progress(const TagStore* store) {
+void report_progress(const osmwayback::TagStore* store) {
     unsigned long last_nodes_count{0};
     unsigned long last_ways_count{0};
     unsigned long last_relations_count{0};
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
     std::string index_dir = argv[1];
     std::string osm_filename = argv[2];
 
-    TagStore store(index_dir, false);
+    osmwayback::TagStore store(index_dir, false);
     TagStoreHandler tag_handler(&store);
 
     std::thread t_progress(report_progress, &store);

--- a/build_tag_lookup.cpp
+++ b/build_tag_lookup.cpp
@@ -1,11 +1,3 @@
-/*
-
-  Build Tag History Database
-
-  (Based on osmium_pub_names example)
-
-*/
-
 #include <cstdlib>  // for std::exit
 #include <cstring>  // for std::strncmp
 #include <iostream> // for std::cout, std::cerr
@@ -85,7 +77,7 @@ int main(int argc, char* argv[]) {
     std::string index_dir = argv[1];
     std::string osm_filename = argv[2];
 
-    TagStore store(index_dir, true);
+    TagStore store(index_dir, false);
     TagStoreHandler tag_handler(&store);
 
     std::thread t_progress(report_progress, &store);

--- a/pbf_encoder.hpp
+++ b/pbf_encoder.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <protozero/pbf_writer.hpp>
+#include <protozero/pbf_reader.hpp>
+
+#include <osmium/osm/types.hpp>
+
+namespace osmwayback {
+    struct Changeset {
+      uint64_t created_at;
+      uint64_t closed_at;
+    };
+
+    const std::string encode_changeset(const osmium::Changeset& changeset) {
+      std::string data;
+      protozero::pbf_writer encoder(data);
+
+      encoder.add_fixed64(1, static_cast<int>(changeset.created_at().seconds_since_epoch()));
+      encoder.add_fixed64(2, static_cast<int>(changeset.closed_at().seconds_since_epoch()));
+
+      return data;
+    }
+
+    const Changeset decode_changeset(std::string data) {
+      protozero::pbf_reader message(data);
+      Changeset changeset{};
+
+		while (message.next()) {
+			switch (message.tag()) {
+				case 1:
+					changeset.created_at = message.get_fixed64();
+					break;
+				case 2:
+					changeset.closed_at = message.get_fixed64();
+					break;
+				default:
+					message.skip();
+			}
+		}
+
+     return changeset;
+    }
+}
+
+

--- a/pbf_encoder.hpp
+++ b/pbf_encoder.hpp
@@ -4,11 +4,13 @@
 #include <protozero/pbf_reader.hpp>
 
 #include <osmium/osm/types.hpp>
+#include <map>
 
 namespace osmwayback {
     struct Changeset {
       uint64_t created_at;
       uint64_t closed_at;
+      std::map<std::string, std::string> tags;
     };
 
     const std::string encode_changeset(const osmium::Changeset& changeset) {
@@ -18,25 +20,42 @@ namespace osmwayback {
       encoder.add_fixed64(1, static_cast<int>(changeset.created_at().seconds_since_epoch()));
       encoder.add_fixed64(2, static_cast<int>(changeset.closed_at().seconds_since_epoch()));
 
+      const osmium::TagList& tags = changeset.tags();
+      for (const osmium::Tag& tag : tags) {
+        encoder.add_string(17, tag.key());
+        encoder.add_string(17, tag.value());
+      }
+
       return data;
     }
 
     const Changeset decode_changeset(std::string data) {
       protozero::pbf_reader message(data);
       Changeset changeset{};
+      changeset.tags = std::map<std::string, std::string>{};
 
-		while (message.next()) {
-			switch (message.tag()) {
-				case 1:
-					changeset.created_at = message.get_fixed64();
-					break;
-				case 2:
-					changeset.closed_at = message.get_fixed64();
-					break;
-				default:
-					message.skip();
-			}
-		}
+      std::string previous_key{};
+        while (message.next()) {
+            switch (message.tag()) {
+                case 1:
+                    changeset.created_at = message.get_fixed64();
+                    break;
+                case 2:
+                    changeset.closed_at = message.get_fixed64();
+                    break;
+                case 17:
+                    changeset.closed_at = message.get_fixed64();
+                    if (previous_key.empty()) {
+                        previous_key = message.get_string();
+                    } else {
+                        changeset.tags[previous_key] = message.get_string();
+                        previous_key = "";
+                    }
+                    break;
+                default:
+                    message.skip();
+            }
+        }
 
      return changeset;
     }


### PR DESCRIPTION
This diverts a bit from tag history. But you need a changeset index to be able to lookup closed and opened time.

Why? With closed/open time we are one step closer to build historic geometries.

For ways we can then lookup all the versions of a node and keep the node version that is closest to the closed timestamp of the changeset.